### PR TITLE
chore: reduce possible metadata errors for zenodo publishing

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,13 +1,11 @@
 {
-    "title": "ctdam",
-    "description": "A python package to handle all steps when working with CTD data",
+    "title": "ctdam: A python package to handle all steps when working with CTD data",
     "version": "1.1.3",
     "creators": [
         {
             "name": "Michels, Emil",
             "orcid": "0009-0003-0300-9465",
-            "affiliation": "German Marine Research Alliance (DAM)",
-            "type": "ProjectMember"
+            "affiliation": "German Marine Research Alliance (DAM)"
         }
     ],
     "keywords": [
@@ -21,7 +19,11 @@
         "data"
     ],
     "access_right": "open",
-    "license": "GPLv3",
+    "license": "GPL-3.0",
     "upload_type": "software",
-    "language": "eng"
+    "communities": [
+        {
+            "identifier": "DAM"
+        }
+    ]
 }


### PR DESCRIPTION
zenodo complains about badly formatted .zenodo.json file