### PR TITLE
fix(proc): default auto-running in procedure is False

### DIFF
--- a/src/ctdam/proc/procedure.py
+++ b/src/ctdam/proc/procedure.py
@@ -71,7 +71,7 @@ class Procedure:
         configuration: dict | Configuration,
         seabird_exe_directory: Path | str | None = None,
         available_hex_converters: list[str] = ["datcnv", "hex2py"],
-        auto_run: bool = True,
+        auto_run: bool = False,
         procedure_fingerprint_directory: Path | str | None = None,
         file_type_dir: Path | str | None = None,
         plot: bool = False,

--- a/tests/proc/test_benchmark_files.py
+++ b/tests/proc/test_benchmark_files.py
@@ -110,6 +110,7 @@ class TestExampleFiles:
         try:
             Procedure(
                 proc_config,
+                auto_run=True,
                 timeout=5,
             )
         except (MissingParameterError, BinnedDataError):

--- a/tests/proc/test_external_functions.py
+++ b/tests/proc/test_external_functions.py
@@ -62,7 +62,8 @@ def test_in_procedure():
                 "wildedit_geomar": {},
                 "Helmholtz_energy_ice": {},
             },
-        }
+        },
+        auto_run=True,
     )
     assert "gsw_Helmholtz_energy_ice_0" in procedure.ctd_data.parameters
 

--- a/tests/proc/test_procedure.py
+++ b/tests/proc/test_procedure.py
@@ -87,7 +87,9 @@ def test_procedure_without_seabird(tmp_path):
             "binavg": {"file_suffix": "_binavg"},
         },
     }
-    procedure = Procedure(proc_config, file_type_dir=file_type_dir)
+    procedure = Procedure(
+        proc_config, auto_run=True, file_type_dir=file_type_dir
+    )
     assert "gsw_Helmholtz_energy_ice_0" in procedure.ctd_data.parameters
     assert (
         "create_bottle_file"
@@ -111,7 +113,8 @@ def test_empty_modules():
             {
                 "input": test_hex,
                 "psa_directory": psa_path,
-            }
+            },
+            auto_run=True,
         )
 
 
@@ -147,7 +150,7 @@ def test_non_seabird_conversion_and_processing(hex, create_files, tmp_path):
             "binavg": {},
         },
     }
-    procedure = Procedure(proc_config, plot=True)
+    procedure = Procedure(proc_config, auto_run=True, plot=True)
     file_path = procedure.ctd_data.path_to_file
     assert isinstance(procedure.ctd_data, CTDData)
     num_of_proc_steps = len(proc_config["modules"]) + 1
@@ -184,5 +187,5 @@ def test_conversion_options():
             "binavg": {},
         },
     }
-    procedure = Procedure(proc_config)
+    procedure = Procedure(proc_config, auto_run=True)
     assert procedure.output.cast_borders["down_start"] == 0


### PR DESCRIPTION
Fixes https://github.com/DAM-CTD-Software/ctdam/issues/29 :

Procedure(proc_settings).run('some_file') assumes a target in proc_settings, which is usually only given as run() parameter.

