### PR TITLE
test(conv): updated path to comparison files converted with Sea-Birds 'datcnv'

### DIFF
--- a/tests/conv/test_hex_conversion.py
+++ b/tests/conv/test_hex_conversion.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import netCDF4 as nc
 import numpy as np
 import pytest
-from conftest import check_and_remove_file, hex_path
+from conftest import check_and_remove_file, cnv_path, hex_path
 from numpy.testing import assert_allclose, assert_equal
 
 from ctdam.conv.hexdecoder import (
@@ -39,16 +39,12 @@ class TestDecoding:
         cast_borders_dict = ctd_data.cast_borders
         try:
             datcnv_cnv = CnvFile(
-                hex_path.joinpath(ctd_data.file_name + "_down").with_suffix(
-                    ".cnv"
-                )
+                cnv_path.joinpath(ctd_data.file_name).with_suffix(".cnv")
             )
         except FileNotFoundError:
-            with pytest.warns(UserWarning):
-                warnings.warn(
-                    f"No comparison file for {ctd_data.metadata_source.file_name}",
-                    UserWarning,
-                )
+            pytest.skip(
+                f"No comparison file for {ctd_data.metadata_source.file_name}"
+            )
         else:
             for parameter in ["t090C", "prDM", "sal11"]:
                 try:
@@ -88,7 +84,6 @@ class TestDecoding:
                     raise AssertionError(
                         f"Parameter {parameter} in {ctd_data.file_name} failed: {error}"
                     )
-        assert True
 
     def test_cast_borders(self, ctd_data: CTDData):
         cast_borders_dict = ctd_data.cast_borders


### PR DESCRIPTION
Wrong legacy path that was used inside seabirdfilehandler

Closes #57