### PR TITLE
Cnv export without unixtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,14 +75,10 @@ Changelog = "https://github.com/DAM-CTD-Software/ctdam/blob/main/CHANGELOG.md"
 [project.scripts]
 ctdam = "ctdam.entry.cli:app"
 
-
-
-
 [tool.pytest.ini_options]
 pythonpath = [".", "src", "src/ctdam"]
 markers = ["seabird", "long"]
 filterwarnings = ['ignore::RuntimeWarning', "ignore::UserWarning"]
-
 
 [tool.ruff]
 line-length = 79
@@ -91,7 +87,6 @@ extend-exclude = ['__init__.py']
 [tool.ruff.lint]
 select = ["ERA001"]
 ignore = ["F403", "F821"]
-
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
@@ -109,9 +104,6 @@ report.sort = "Cover"
 [tool.hatch.build.targets.wheel]
 packages = ["src/ctdam"]
 
-
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
-

--- a/src/ctdam/parser/cnvfile.py
+++ b/src/ctdam/parser/cnvfile.py
@@ -101,9 +101,9 @@ class CnvFile(DataFile):
     def absolute_time_calculation(self) -> bool:
         """
         Replaces the basic cnv time representation of counting relative to the
-        casts start point, by real UTC timestamps.
+        casts start point, by a unix timestamp.
 
-        A new parameter column, 'datetime', will be created.
+        A new parameter column, 'timeU', will be created.
 
         Returns
         -------

--- a/src/ctdam/parser/ctddata.py
+++ b/src/ctdam/parser/ctddata.py
@@ -530,6 +530,7 @@ class CTDData:
         output_parameters: list[str] | Literal["all", "default"] = "all",
         reduced_header: bool = False,
         bad_flag: float = -9.990e-29,
+        seabird_compatible: bool = True,
     ):
         """
         Writes the data and metadata inside of this instance as new .cnv
@@ -567,6 +568,8 @@ class CTDData:
         if remove_flags:
             self.drop_flagged_rows(parameters)
         self.pick_output_columns(parameters, output_parameters)
+        if seabird_compatible:
+            parameters.remove_parameter("timeU")
         parameters.sort_parameters()
         # create output format
         data = self.array2cnv(parameters, bad_flag)

--- a/src/ctdam/parser/parameter.py
+++ b/src/ctdam/parser/parameter.py
@@ -150,6 +150,19 @@ class Parameters(UserDict):
                 sample_rate = 24
             return sample_rate
 
+    def remove_parameter(self, parameter: str):
+        """
+        Remove a parameter.
+
+        Parameters
+        ----------
+        parameter : str
+            A name of the parameter to be removed
+
+        """
+        if parameter in self.get_names():
+            self.data.pop(parameter)
+
     def create_full_ndarray(self, data_table: list = []) -> np.ndarray:
         """
         Parser for .cnv data table data.

--- a/tests/parser/test_parameter_class.py
+++ b/tests/parser/test_parameter_class.py
@@ -57,3 +57,8 @@ def test_addition_of_new_parameters(
     assert new_parameter.name in parameters
     assert new_parameter.data.shape[0] == data_table_length
     assert len(new_parameter.metadata) == 5
+
+
+def test_parameter_removal(parameters):
+    parameters.remove_parameter("prDM")
+    assert "prDM" not in parameters


### PR DESCRIPTION
Building on #67, adds an option to produce seabird-compatible .cnv files, where the unix timestamp is removed. Does close #68 by clarifying the usage of unix timestamps in the docstring.

By adding a method for parameter removal, this also closes #54.