### PR TITLE
fix(parser): convert timeU to float not to int

### DIFF
--- a/src/ctdam/parser/cnvfile.py
+++ b/src/ctdam/parser/cnvfile.py
@@ -127,7 +127,7 @@ class CnvFile(DataFile):
             name="timeU",
             data=np.array(
                 [(self.start_time + d).timestamp() for d in data]
-            ).astype("int"),
+            ).astype("float"),
         )
         return True
 


### PR DESCRIPTION
Converting the unix timestamp timeU to float does not allow digits, therefore no higher time resolutions then one second.