### PR TITLE
fix(conv): also parse unix time information to floats when converting from hex

### DIFF
--- a/src/ctdam/conv/hexdecoder.py
+++ b/src/ctdam/conv/hexdecoder.py
@@ -223,7 +223,7 @@ def handle_time(
     corrected_time_array = seconds_since_start + start_time_posix
 
     parameters.create_parameter(
-        corrected_time_array.astype("int"),
+        corrected_time_array.astype("float"),
         name="timeU",
     )
 


### PR DESCRIPTION

Following #75 where this was done for the cnv parser