### PR TITLE
Feature/proc update df

### DIFF
--- a/src/ctdam/parser/cnvfile.py
+++ b/src/ctdam/parser/cnvfile.py
@@ -98,6 +98,19 @@ class CnvFile(DataFile):
         self.df = self.parameters.get_pandas_dataframe()
         return self.df
 
+    def update_dataframe(self):
+        """
+        Updates the existing datframe with a new one created from the current paramters. For the exact behaviour see pandas.update().
+        """
+        # Check if there is a dataframe already
+        if isinstance(self.df, pd.DataFrame):
+            new_df = self.parameters.get_pandas_dataframe()
+            self.df.update(new_df)
+        else:
+            raise ValueError(
+                "Cannot update dataframe, no dataframe exists!"
+            )
+
     def absolute_time_calculation(self) -> bool:
         """
         Replaces the basic cnv time representation of counting relative to the

--- a/src/ctdam/proc/procedure.py
+++ b/src/ctdam/proc/procedure.py
@@ -197,6 +197,7 @@ class Procedure:
         self.output_name = self.check_config_entry("output_name", None)
         self.output_type = self.check_config_entry("output_type", "cnv")
         self.output_columns = self.check_config_entry("output_columns", "all")
+        self.update_df = self.check_config_entry("update_df", True)
         self.xmlcon = self.check_config_entry("xmlcon", None)
         self.bad_flag = self.check_config_entry("bad_flag", -9.990e-29)
         self.downcast_only = self.check_config_entry("downcast_only", True)
@@ -432,6 +433,10 @@ class Procedure:
                         )
                         break
                 last_step = "internal"
+        # update dataframe
+        if self.update_df:
+            self.ctd_data.update_dataframe()
+
         # handle output
         if self.output_type == "cnv":
             if last_step == "internal":

--- a/src/ctdam/proc/procedure.py
+++ b/src/ctdam/proc/procedure.py
@@ -197,7 +197,7 @@ class Procedure:
         self.output_name = self.check_config_entry("output_name", None)
         self.output_type = self.check_config_entry("output_type", "cnv")
         self.output_columns = self.check_config_entry("output_columns", "all")
-        self.update_df = self.check_config_entry("update_df", True)
+        self.update_df = self.check_config_entry("update_df", False)
         self.xmlcon = self.check_config_entry("xmlcon", None)
         self.bad_flag = self.check_config_entry("bad_flag", -9.990e-29)
         self.downcast_only = self.check_config_entry("downcast_only", True)


### PR DESCRIPTION
This adds the option to update an existing dataframe inside the CTDdata object during processing. When the option is `"update_df" : True` in the processing config the last step during the processing creates a new dataframe and updates the current one using the [pandas update](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.update.html) function.