### PR TITLE
Add error margin support to range QC

### DIFF
--- a/src/ctdam/qc/range_checks.py
+++ b/src/ctdam/qc/range_checks.py
@@ -11,11 +11,17 @@ from ctdam.qc.quality_flags import SeaDataNetFlag
 class RangeLimit:
     """
     Range limits for one CTD parameter.
+
+    Values inside the valid range are flagged as probably good.
+    Values slightly outside the valid range but inside the error margin are
+    flagged as probably bad.
+    Values outside the range and margin are flagged as bad.
     """
 
     parameter_name: str
     minimum: float | None = None
     maximum: float | None = None
+    error_margin: float = 0.0
     test_name: str = "range_check"
 
 
@@ -24,54 +30,63 @@ DEFAULT_RANGE_LIMITS: dict[str, RangeLimit] = {
         parameter_name="prDM",
         minimum=0.0,
         maximum=10000.0,
+        error_margin=1.0,
         test_name="pressure_range",
     ),
     "t090C": RangeLimit(
         parameter_name="t090C",
         minimum=-2.0,
         maximum=50.0,
+        error_margin=0.5,
         test_name="temperature_range",
     ),
     "t190C": RangeLimit(
         parameter_name="t190C",
         minimum=-2.0,
         maximum=50.0,
+        error_margin=0.5,
         test_name="temperature_2_range",
     ),
     "c0mS/cm": RangeLimit(
         parameter_name="c0mS/cm",
         minimum=0.0,
         maximum=100.0,
+        error_margin=0.1,
         test_name="conductivity_range",
     ),
     "c1mS/cm": RangeLimit(
         parameter_name="c1mS/cm",
         minimum=0.0,
         maximum=100.0,
+        error_margin=0.1,
         test_name="conductivity_2_range",
     ),
     "sal00": RangeLimit(
         parameter_name="sal00",
         minimum=0.0,
         maximum=60.0,
+        error_margin=0.05,
         test_name="salinity_range",
     ),
     "sal11": RangeLimit(
         parameter_name="sal11",
         minimum=0.0,
         maximum=60.0,
+        error_margin=0.05,
         test_name="salinity_2_range",
     ),
     "sbox0Mm/Kg": RangeLimit(
         parameter_name="sbox0Mm/Kg",
         minimum=0.0,
         maximum=300.0,
+        error_margin=5.0,
         test_name="oxygen_range",
     ),
     "sbox1Mm/Kg": RangeLimit(
         parameter_name="sbox1Mm/Kg",
         minimum=0.0,
         maximum=300.0,
+        error_margin=5.0,
         test_name="oxygen_2_range",
     ),
 }
@@ -85,7 +100,9 @@ def apply_range_check_to_parameter(
     Apply range QC to one Parameter.
 
     Passing values are flagged as 2 = probably good.
-    Failing values are flagged as 4 = bad.
+    Values outside the range but inside the error margin are flagged as
+    3 = probably bad.
+    Values outside the range and error margin are flagged as 4 = bad.
     Missing or declared bad-fill values are flagged as 9 = missing.
     """
     limit = limit or DEFAULT_RANGE_LIMITS.get(parameter.name)
@@ -110,19 +127,31 @@ def apply_range_check_to_parameter(
         getattr(parameter, "bad_flag", None),
     )
 
+    valid = finite & ~declared_bad
     missing_mask = ~finite | declared_bad
 
-    fail_mask = np.zeros(values.shape, dtype=bool)
+    error_margin = max(float(limit.error_margin), 0.0)
 
-    valid = finite & ~declared_bad
+    probably_bad_mask = np.zeros(values.shape, dtype=bool)
+    bad_mask = np.zeros(values.shape, dtype=bool)
 
     if limit.minimum is not None:
-        fail_mask |= valid & (values < limit.minimum)
+        probably_bad_mask |= (
+            valid
+            & (values < limit.minimum)
+            & (values >= limit.minimum - error_margin)
+        )
+        bad_mask |= valid & (values < limit.minimum - error_margin)
 
     if limit.maximum is not None:
-        fail_mask |= valid & (values > limit.maximum)
+        probably_bad_mask |= (
+            valid
+            & (values > limit.maximum)
+            & (values <= limit.maximum + error_margin)
+        )
+        bad_mask |= valid & (values > limit.maximum + error_margin)
 
-    pass_mask = valid & ~fail_mask
+    pass_mask = valid & ~probably_bad_mask & ~bad_mask
 
     changed = 0
 
@@ -130,14 +159,31 @@ def apply_range_check_to_parameter(
         mask=pass_mask,
         new_flag=SeaDataNetFlag.PROBABLY_GOOD,
         test_name=limit.test_name,
-        reason=f"value passed range test: min={limit.minimum}, max={limit.maximum}",
+        reason=(
+            f"value passed range test: min={limit.minimum}, "
+            f"max={limit.maximum}, error_margin={error_margin}"
+        ),
     )
 
     changed += parameter.update_flags(
-        mask=fail_mask,
+        mask=probably_bad_mask,
+        new_flag=SeaDataNetFlag.PROBABLY_BAD,
+        test_name=limit.test_name,
+        reason=(
+            f"value inside range error margin: min={limit.minimum}, "
+            f"max={limit.maximum}, error_margin={error_margin}"
+        ),
+    )
+
+    changed += parameter.update_flags(
+        mask=bad_mask,
         new_flag=SeaDataNetFlag.BAD,
         test_name=limit.test_name,
-        reason=f"value failed range test: min={limit.minimum}, max={limit.maximum}",
+        reason=(
+            f"value failed range test beyond error margin: "
+            f"min={limit.minimum}, max={limit.maximum}, "
+            f"error_margin={error_margin}"
+        ),
     )
 
     changed += parameter.update_flags(
@@ -161,7 +207,8 @@ def apply_range_check(
         return 0
 
     return apply_range_check_to_parameter(
-        ctd_data[limit.parameter_name], limit
+        ctd_data[limit.parameter_name],
+        limit,
     )
 
 

--- a/tests/qc/test_range_checks.py
+++ b/tests/qc/test_range_checks.py
@@ -143,3 +143,61 @@ def test_parameter_instantiation_flags_missing_values_as_9():
     assert parameter.flags[0] == int(SeaDataNetFlag.PROBABLY_GOOD)
     assert parameter.flags[1] == int(SeaDataNetFlag.MISSING)
     assert parameter.flags[2] == int(SeaDataNetFlag.MISSING)
+
+
+def test_apply_range_check_flags_values_inside_error_margin_as_probably_bad():
+    ctd_data = DummyCTDData()
+    ctd_data["dummy_temp"] = make_parameter(
+        "dummy_temp",
+        [-2.2, 10.0, 50.3],
+    )
+
+    limit = RangeLimit(
+        parameter_name="dummy_temp",
+        minimum=-2.0,
+        maximum=50.0,
+        error_margin=0.5,
+        test_name="temperature_range",
+    )
+
+    changed = apply_range_check(ctd_data, limit)
+
+    assert changed == 3
+    assert np.array_equal(
+        ctd_data["dummy_temp"].flags,
+        np.array([3, 2, 3], dtype=np.int8),
+    )
+
+    assert (
+        "inside range error margin" in ctd_data["dummy_temp"].flag_history[0]
+    )
+    assert (
+        "inside range error margin" in ctd_data["dummy_temp"].flag_history[2]
+    )
+
+
+def test_apply_range_check_flags_values_beyond_error_margin_as_bad():
+    ctd_data = DummyCTDData()
+    ctd_data["dummy_temp"] = make_parameter(
+        "dummy_temp",
+        [-3.0, 10.0, 51.0],
+    )
+
+    limit = RangeLimit(
+        parameter_name="dummy_temp",
+        minimum=-2.0,
+        maximum=50.0,
+        error_margin=0.5,
+        test_name="temperature_range",
+    )
+
+    changed = apply_range_check(ctd_data, limit)
+
+    assert changed == 3
+    assert np.array_equal(
+        ctd_data["dummy_temp"].flags,
+        np.array([4, 2, 4], dtype=np.int8),
+    )
+
+    assert "beyond error margin" in ctd_data["dummy_temp"].flag_history[0]
+    assert "beyond error margin" in ctd_data["dummy_temp"].flag_history[2]


### PR DESCRIPTION
Note: Focused QC tests pass locally. A full test-suite run currently fails in tests/conv/test_hex_conversion.py::TestDecoding::test_cnv_export with NoDataError while reading an exported CNV file, which appears unrelated to this range QC change. 