### PR TITLE
Issue 131 sample rate

### DIFF
--- a/src/ctdam/parser/custom_xarray_accessors.py
+++ b/src/ctdam/parser/custom_xarray_accessors.py
@@ -323,9 +323,14 @@ class DataRetrievalAccessor:
         return self._ds.scan.size
 
     @property
-    def sample_rate(self) -> float:
-        # TODO: implement real parsing
-        return 24
+    def sample_rate(self) -> float | str:
+        if "sample_rate" in self._ds.attrs and self._ds.attrs["sample_rate"]:
+            return self._ds.attrs["sample_rate"]
+
+        try:
+            return float(np.round(1 / np.mean(np.diff(self._ds.time.data))))
+        except Exception:
+            return 24
 
     @property
     def binned(self) -> bool:

--- a/src/ctdam/parser/custom_xarray_accessors.py
+++ b/src/ctdam/parser/custom_xarray_accessors.py
@@ -12,10 +12,10 @@ import pandas as pd
 import xarray as xr
 
 from ctdam import PARAMETER_MAPPING, SBS_NAME_MAPPING
+from ctdam.exceptions import BinnedDataError
 from ctdam.parser.seabird_data_files import BottleLogFile
 from ctdam.proc.modules.available_modules import map_proc_name_to_class
 from ctdam.proc.workflow import Workflow
-from ctdam.exceptions import BinnedDataError
 
 logger = logging.getLogger(__name__)
 
@@ -323,14 +323,30 @@ class DataRetrievalAccessor:
         return self._ds.scan.size
 
     @property
-    def sample_rate(self) -> float | str:
+    def sample_rate(self) -> int:
         if "sample_rate" in self._ds.attrs and self._ds.attrs["sample_rate"]:
-            return self._ds.attrs["sample_rate"]
+            sample_rate = self._ds.attrs["sample_rate"]
+            try:
+                sample_rate = int(sample_rate)
+            except Exception:
+                sample_rate = int(sample_rate.split()[0])
+            return sample_rate
 
         try:
-            return float(np.round(1 / np.mean(np.diff(self._ds.time.data))))
+            return int(np.round(1 / np.mean(np.diff(self._ds.time.data))))
         except Exception:
             return 24
+
+    @property
+    def bin_unit(self) -> str:
+        if "sample_rate" in self._ds.attrs and self._ds.attrs["sample_rate"]:
+            sample_rate = self._ds.attrs["sample_rate"]
+            try:
+                sample_rate = int(sample_rate)
+            except Exception:
+                return sample_rate.split()[1]
+
+        return ""
 
     @property
     def binned(self) -> bool:

--- a/src/ctdam/parser/read_ctd_data.py
+++ b/src/ctdam/parser/read_ctd_data.py
@@ -46,7 +46,21 @@ def create_array_attrs(raw_file_data: SeabirdDataFile) -> dict:
     attrs["cruise"] = raw_file_data.cruise
     attrs["station"] = raw_file_data.event_name
     attrs["path_to_source_file"] = str(raw_file_data.path_to_file.absolute())
-    attrs["sample_rate"] = ""
+    for line in raw_file_data.data_table_description:
+        if line.startswith("interval"):
+            unit, value = line.split("=", 1)[1].split(":", 1)
+            unit = unit.strip()
+            value = float(value.strip())
+
+            if unit == "seconds":
+                sample_rate = float(np.round(1 / value))
+                if sample_rate == 1:
+                    attrs["sample_rate"] = f"{value:g} second"
+                else:
+                    attrs["sample_rate"] = sample_rate
+            elif unit in ("decibars", "db"):
+                attrs["sample_rate"] = f"{value:g} dbar"
+            break
 
     # instrument metadata
     attrs["instrument_metadata"] = "".join(raw_file_data.instrument_metadata)

--- a/src/ctdam/parser/read_ctd_data.py
+++ b/src/ctdam/parser/read_ctd_data.py
@@ -46,6 +46,7 @@ def create_array_attrs(raw_file_data: SeabirdDataFile) -> dict:
     attrs["cruise"] = raw_file_data.cruise
     attrs["station"] = raw_file_data.event_name
     attrs["path_to_source_file"] = str(raw_file_data.path_to_file.absolute())
+    attrs["sample_rate"] = ""
     for line in raw_file_data.data_table_description:
         if line.startswith("interval"):
             unit, value = line.split("=", 1)[1].split(":", 1)

--- a/src/ctdam/parser/sst_ctd_file_parser.py
+++ b/src/ctdam/parser/sst_ctd_file_parser.py
@@ -248,6 +248,7 @@ def _add_metadata(ds, input_path, date_format):
         "cruise": "",
         "station": "",
         "path_to_source_file": str(input_path),
+        "sample_rate": "",
         "instrument_metadata": "",
         "custom_metadata": "",
         "sensor_metadata": "",

--- a/src/ctdam/parser/sst_ctd_file_parser.py
+++ b/src/ctdam/parser/sst_ctd_file_parser.py
@@ -248,7 +248,6 @@ def _add_metadata(ds, input_path, date_format):
         "cruise": "",
         "station": "",
         "path_to_source_file": str(input_path),
-        "sample_rate": "",
         "instrument_metadata": "",
         "custom_metadata": "",
         "sensor_metadata": "",

--- a/tests/test_xarray_accessors.py
+++ b/tests/test_xarray_accessors.py
@@ -95,3 +95,13 @@ def test_bottle_info_parsing():
     ds.add.bottles(bl)
     btl_info = ds.access.btl_info
     assert btl_info.bottle_info.size == 7
+
+def test_sample_rate_accessor():
+    ds = read_cnv(cnv_path / "EMB295_14-1.cnv")
+    assert ds.access.sample_rate == 24
+
+    binned_ds = read_cnv(cnv_path / "EMB394_006-01_CTD_0006_1m.cnv")
+    assert binned_ds.access.sample_rate == "1 dbar"
+
+    ds.attrs["sample_rate"] = "1 second"
+    assert ds.access.sample_rate == "1 second"

--- a/tests/test_xarray_accessors.py
+++ b/tests/test_xarray_accessors.py
@@ -96,12 +96,15 @@ def test_bottle_info_parsing():
     btl_info = ds.access.btl_info
     assert btl_info.bottle_info.size == 7
 
+
 def test_sample_rate_accessor():
     ds = read_cnv(cnv_path / "EMB295_14-1.cnv")
     assert ds.access.sample_rate == 24
 
     binned_ds = read_cnv(cnv_path / "EMB394_006-01_CTD_0006_1m.cnv")
-    assert binned_ds.access.sample_rate == "1 dbar"
+    assert binned_ds.access.sample_rate == 1
+    assert binned_ds.access.bin_unit == "dbar"
 
     ds.attrs["sample_rate"] = "1 second"
-    assert ds.access.sample_rate == "1 second"
+    assert ds.access.sample_rate == 1
+    assert ds.access.bin_unit == "second"


### PR DESCRIPTION
Implement ds.access.sample_rate for the v2 xarray structure.
Parse CNV # interval metadata and store it in the Dataset sample_rate attribute.
Return values such as 24.0, "1 dbar", and "1 second".
Fall back to calculating the sampling rate from time spacing when needed.
Add focused tests for unbinned and binned CNV data.