### PR TITLE
Add temperature uncertainty metadata

### DIFF
--- a/src/ctdam/parameter_name_mapping.toml
+++ b/src/ctdam/parameter_name_mapping.toml
@@ -13,6 +13,7 @@ name = "Press"
 unit = "dBar"
 
 [temperature]
+uncertainty = 0.001
 [temperature.seabird]
 [temperature.seabird.primary]
 shortname = "t090C"

--- a/src/ctdam/parser/custom_xarray_accessors.py
+++ b/src/ctdam/parser/custom_xarray_accessors.py
@@ -149,15 +149,21 @@ class InputAccessor:
         else:
             dims = ("scan",)
             ancillary_variable = np.zeros((len(data)), dtype="i1")
+        parameter_attrs = {
+            "standard_name": cf_name,
+            "units": PARAMETER_MAPPING[basic_name]["cf"]["unit"],
+            "ancillary_variables": ancillary_variable_name,
+        }
+
+        if "uncertainty" in PARAMETER_MAPPING[basic_name]:
+            parameter_attrs["uncertainty"] = PARAMETER_MAPPING[basic_name][
+                "uncertainty"
+            ]
 
         self._ds[basic_name] = (
             dims,
             data,
-            {
-                "standard_name": cf_name,
-                "units": PARAMETER_MAPPING[basic_name]["cf"]["unit"],
-                "ancillary_variables": ancillary_variable_name,
-            },
+            parameter_attrs,
         )
 
         self._ds[ancillary_variable_name] = (
@@ -386,6 +392,20 @@ class MetadataAccessor:
             metadata_dict[key.strip()] = value.strip()
 
         return metadata_dict
+
+
+@xr.register_dataset_accessor("uncertainty")
+class UncertaintyAccessor:
+    def __init__(self, ds):
+        self._ds = ds
+
+    def get(self, name: str) -> float | None:
+        """Return the uncertainty of a parameter."""
+        return self._ds[name].attrs.get("uncertainty")
+
+    def set(self, name: str, value: float):
+        """Set the uncertainty of a parameter."""
+        self._ds[name].attrs["uncertainty"] = float(value)
 
 
 @xr.register_dataset_accessor("access")

--- a/tests/test_xarray_accessors.py
+++ b/tests/test_xarray_accessors.py
@@ -27,6 +27,16 @@ def test_cnv_xarray_parsing(ds, create_files):
         file_path.unlink()
 
 
+def test_temperature_uncertainty(ds):
+    if "temperature" not in ds:
+        pytest.skip("Dataset has no temperature parameter.")
+
+    assert ds.uncertainty.get("temperature") == 0.001
+
+    ds.uncertainty.set("temperature", 0.002)
+    assert ds["temperature"].attrs["uncertainty"] == 0.002
+
+
 def test_workflow_processing(ds, create_files, tmp_path):
     proc_settings = {
         "modules": {


### PR DESCRIPTION
Introduces scalar uncertainty metadata for CTD parameters, using temperature as the first implementation.

adds the SBE temperature uncertainty of 0.001 °C to parameter_name_mapping.toml
stores uncertainty as an attribute of the existing xarray parameter
adds ds.uncertainty.get() / set() for accessing and updating the value
adds a focused test for temperature uncertainty

One uncertainty value is stored per parameter, so it applies to both temperature sensor strands.
Propagation through processing operations will be handled separately.


Testing: test_temperature_uncertainty: 9 passed, 1 skipped.
The existing CNV export/re-import tests still fail with the pre-existing UnexpectedFileFormat issue and are unrelated to this change.