### PR TITLE
154 add option to run cast borders automatically on hex conversion

### DIFF
--- a/src/ctdam/parser/custom_xarray_accessors.py
+++ b/src/ctdam/parser/custom_xarray_accessors.py
@@ -225,16 +225,12 @@ class InputAccessor:
         else:
             long_name = "bottle firing indicator"
 
-        scan_offset = self._ds.attrs.get("scan_offset", 0)
         for _, line in df.iterrows():
-            start = int(line.start_range) - scan_offset
-            end = int(line.end_range) - scan_offset
+            mask = (self._ds.scan >= int(line.start_range)) & (
+                self._ds.scan < int(line.end_range)
+            )
 
-            start = max(start, 0)
-            end = min(end, len(bl_info_array))
-
-            if start < end:
-                bl_info_array[start:end] = line["Bottle ID"]
+            bl_info_array[mask] = line["Bottle ID"]
 
         self._ds["bottle_info"] = xr.DataArray(
             bl_info_array,

--- a/src/ctdam/parser/read_ctd_data.py
+++ b/src/ctdam/parser/read_ctd_data.py
@@ -280,6 +280,7 @@ def build_sensor_pairs(
 
 def read_hex(
     path_to_hex_file: Path | str,
+    downcast_only: bool = True,
 ) -> xr.Dataset:
     """
     Parse Seabird .hex data to cf-compliant xarray Dataset.
@@ -446,6 +447,16 @@ def read_hex(
                     ]
                 ),
             )
+
+    if downcast_only:
+        from ctdam.proc.modules.detect_cast_borders import CastBorders
+
+        ds = CastBorders()(
+            ds=ds,
+            arguments={
+                "crop": True,
+            },
+        )
 
     return ds
 

--- a/src/ctdam/parser/read_ctd_data.py
+++ b/src/ctdam/parser/read_ctd_data.py
@@ -450,7 +450,6 @@ def read_hex(
 
     if downcast_only:
         from ctdam.proc.modules.detect_cast_borders import CastBorders
-
         ds = CastBorders()(
             ds=ds,
             arguments={

--- a/src/ctdam/parser/read_ctd_data.py
+++ b/src/ctdam/parser/read_ctd_data.py
@@ -450,6 +450,7 @@ def read_hex(
 
     if downcast_only:
         from ctdam.proc.modules.detect_cast_borders import CastBorders
+
         ds = CastBorders()(
             ds=ds,
             arguments={

--- a/src/ctdam/proc/modules/detect_cast_borders.py
+++ b/src/ctdam/proc/modules/detect_cast_borders.py
@@ -54,8 +54,6 @@ class CastBorders(Module):
         return True
 
     def _crop_to_downcast(self, start: int, end: int) -> None:
-        self.ds.attrs["scan_offset"] = start
-
         self.ds = self.ds.isel(scan=slice(start, end))
 
         self.flags = self.flags[start:end]

--- a/tests/test_hex_conversion.py
+++ b/tests/test_hex_conversion.py
@@ -12,7 +12,7 @@ from ctdam.parser.read_ctd_data import read_cnv, read_hex
 def ds(request):
     if request.param.stem == "EMB379_000-00_SF_0001":
         pytest.skip("PyroScience Oxygen Sensor not supported yet.")
-    return read_hex(request.param)
+    return read_hex(request.param, downcast_only=False)
 
 
 class TestHexConversion:
@@ -62,4 +62,16 @@ class TestHexConversion:
         )
         ds.export.to_cnv(file_path)
         if not create_files:
-            file_path.unlink()
+            file_path.unlink() 
+    
+    def test_downcast_only(self, ds):
+        file_path = Path(ds.attrs["path_to_source_file"])
+
+        downcast = read_hex(
+            file_path,
+            downcast_only=True,
+        )
+
+        assert downcast.sizes["scan"] < ds.sizes["scan"]
+        assert "scan_offset" in downcast.attrs
+        assert "castborders" in downcast.meta.provenance      

--- a/tests/test_hex_conversion.py
+++ b/tests/test_hex_conversion.py
@@ -62,8 +62,8 @@ class TestHexConversion:
         )
         ds.export.to_cnv(file_path)
         if not create_files:
-            file_path.unlink() 
-    
+            file_path.unlink()
+
     def test_downcast_only(self, ds):
         file_path = Path(ds.attrs["path_to_source_file"])
 
@@ -73,5 +73,4 @@ class TestHexConversion:
         )
 
         assert downcast.sizes["scan"] < ds.sizes["scan"]
-        assert "scan_offset" in downcast.attrs
-        assert "castborders" in downcast.meta.provenance      
+        assert "castborders" in downcast.meta.provenance

--- a/tests/test_processing_modules.py
+++ b/tests/test_processing_modules.py
@@ -222,22 +222,28 @@ def test_bottles_after_cast_border_crop():
     ds = read_ctd_data(cnv_path / file_name)
 
     ds.add.bottles(bl_file=BottleLogFile(bl_file))
-    original = ds.bottle_info.values.copy()
 
     cropped = CastBorders()(
-        ds=ds.drop_vars("bottle_info"),
-        arguments={"crop": True},
+        ds=ds.drop_vars("bottle_info"), arguments={"crop": True}
     )
 
-    offset = cropped.attrs["scan_offset"]
     cropped.add.bottles(bl_file=BottleLogFile(bl_file))
 
-    for bottle in np.unique(original[original != 0]):
-        expected = np.where(original == bottle)[0] - offset
-        expected = expected[
-            (expected >= 0) & (expected < cropped.sizes["scan"])
+    for bottle in np.unique(
+        cropped.bottle_info.values[cropped.bottle_info.values != 0]
+    ):
+        original_scans = ds.scan.values[ds.bottle_info.values == bottle]
+
+        cropped_scans = cropped.scan.values[
+            cropped.bottle_info.values == bottle
         ]
 
-        actual = np.where(cropped.bottle_info.values == bottle)[0]
-
-        assert np.array_equal(actual, expected)
+        assert np.array_equal(
+            cropped_scans,
+            original_scans[
+                np.isin(
+                    original_scans,
+                    cropped.scan.values,
+                )
+            ],
+        )

--- a/tests/test_processing_workflows.py
+++ b/tests/test_processing_workflows.py
@@ -64,7 +64,7 @@ def test_gsw_xarray_workflow_processing(ds):
     )
 
 
-@pytest.mark.long
+# @pytest.mark.long
 @pytest.mark.parametrize(
     "hex", [filename for filename in hex_path.glob("*.hex")]
 )
@@ -75,6 +75,9 @@ def test_full_conversion_and_processing(hex, tmp_path):
         "output_type": "ctd_data",
         "output_dir": tmp_path,
         "modules": {
+            "cast_borders": {
+                "crop": True,
+            },
             "wildedit_geomar": {},
             "wfilter": {},
             "airpressure": {},

--- a/tests/test_processing_workflows.py
+++ b/tests/test_processing_workflows.py
@@ -1,11 +1,11 @@
 import pytest
 from conftest import (
+    assert_different_np_array,
     cnv_path,
     hex_path,
     psa_path,
-    test_hex,
-    assert_different_np_array,
     test_cnv,
+    test_hex,
 )
 
 from ctdam.exceptions import BinnedDataError, MissingParameterError
@@ -64,7 +64,7 @@ def test_gsw_xarray_workflow_processing(ds):
     )
 
 
-# @pytest.mark.long
+@pytest.mark.long
 @pytest.mark.parametrize(
     "hex", [filename for filename in hex_path.glob("*.hex")]
 )


### PR DESCRIPTION
I changed how the indexing shift was handled. Instead of calculating an offset and saving it, I now use the existing scan coordinates after cropping to ensure that bottle ranges still refer to the original scan indices. Thats more elegant and uses the xarray functionality