### PR TITLE
ci: pin gitpython version to circumvent python-semantic-release problem

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ docs = [
     "myst-parser>=4.0.1",
     "click-extra[sphinx]>=7.9.0",
 ]
-release = ["python-semantic-release>=9.21.1"]
+release = ["python-semantic-release>=9.21.1", "gitpython==3.1.59"]
 
 [project.urls]
 Homepage = "https://github.com/DAM-CTD-Software/ctdam"


### PR DESCRIPTION
Following https://github.com/python-semantic-release/python-semantic-release/issues/1475